### PR TITLE
Rename `shinjuku-lt-timetable` -> `timetable-bot`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# shinjuku-lt-timetable
+# timetable-bot
 
 SlackBot to generate lt-timetable 🏭
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "shinjuku-lt-timetable",
+  "name": "timetable-bot",
   "version": "1.0.0",
-  "description": "lt timetable generator",
+  "description": "bot to generate lt-timetable",
   "main": "index.js",
   "scripts": {
     "start": "node index.js"


### PR DESCRIPTION
## Overview
it is redundant, renamed the repository name
